### PR TITLE
Release and use generated tarball instead of github archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,5 +41,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            *-src-*.tar.gz
+            *.tar.gz
             *.src.rpm

--- a/openbao.spec
+++ b/openbao.spec
@@ -13,7 +13,7 @@ Summary: A tool for securely accessing secrets
 # See LICENSE for primary license
 # See LICENSE_DEPENDENCIES.md for bundled dependencies
 License: MPL-2.0
-Source0: https://github.com/opensciencegrid/%{name}-rpm/archive/v%{package_version}/%{name}-rpm-%{package_version}.tar.gz
+Source0: https://github.com/opensciencegrid/%{name}-rpm/releases/download/v%{package_version}/%{name}-rpm-%{package_version}.tar.gz
 # This is created by ./make-source-tarball and included in release assets
 Source1: https://github.com/opensciencegrid/%{name}-rpm/releases/download/v%{package_version}/%{name}-src-%{package_version}.tar.gz
 

--- a/openbao.spec.in
+++ b/openbao.spec.in
@@ -13,7 +13,7 @@ Summary: A tool for securely accessing secrets
 # See LICENSE for primary license
 # See LICENSE_DEPENDENCIES.md for bundled dependencies
 License: MPL-2.0
-Source0: https://github.com/opensciencegrid/%{name}-rpm/archive/v%{package_version}/%{name}-rpm-%{package_version}.tar.gz
+Source0: https://github.com/opensciencegrid/%{name}-rpm/releases/download/v%{package_version}/%{name}-rpm-%{package_version}.tar.gz
 # This is created by ./make-source-tarball and included in release assets
 Source1: https://github.com/opensciencegrid/%{name}-rpm/releases/download/v%{package_version}/%{name}-src-%{package_version}.tar.gz
 


### PR DESCRIPTION
Fedora wants the md5sums to match and I can't figure out how to match the github archive generated tarball.